### PR TITLE
fix: build obot elasticsearch image to fix the http address

### DIFF
--- a/.github/workflows/docker-build-and-push.yml
+++ b/.github/workflows/docker-build-and-push.yml
@@ -21,6 +21,7 @@ jobs:
           - phat
           - github
           - hubspot
+          - elasticsearch
     runs-on: depot-ubuntu-22.04
     steps:
       - name: Checkout code

--- a/Dockerfile.elasticsearch
+++ b/Dockerfile.elasticsearch
@@ -1,0 +1,3 @@
+FROM docker.elastic.co/mcp/elasticsearch:0.4.5
+
+ENV HTTP_ADDRESS=0.0.0.0:8080


### PR DESCRIPTION
https://github.com/obot-platform/obot/issues/4069
basically doing the same as https://github.com/elastic/mcp-server-elasticsearch/blob/main/Dockerfile-8000#L38
