### PR TITLE
add redis to repackage

### DIFF
--- a/repackaging/images.yaml
+++ b/repackaging/images.yaml
@@ -95,3 +95,7 @@ images:
     type: node
     package: "@dynatrace-oss/dynatrace-mcp-server"
     version: 0.6.1
+  - name: redis
+    type: python
+    package: git+https://github.com/redis/mcp-redis.git
+    version: main

--- a/repackaging/images.yaml
+++ b/repackaging/images.yaml
@@ -97,5 +97,5 @@ images:
     version: 0.6.1
   - name: redis
     type: python
-    package: git+https://github.com/redis/mcp-redis.git
-    version: main
+    package: redis-mcp-server
+    version: 0.3.0


### PR DESCRIPTION
package is git+https://github.com/redis/mcp-redis.git. 
the 0.2.0 was broken and they patched a fix in the main branch