### PR TITLE
fix: bump nanobot image and add extra flags

### DIFF
--- a/Dockerfile.nanobot
+++ b/Dockerfile.nanobot
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.61 /usr/local/bin/nanobot /usr/local/bin/
+COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.66 /usr/local/bin/nanobot /usr/local/bin/
 
 COPY ./scripts/nanobot.sh /usr/local/bin/nanobot.sh
 

--- a/Dockerfile.phat
+++ b/Dockerfile.phat
@@ -1,4 +1,4 @@
-FROM ghcr.io/nanobot-ai/nanobot:v0.0.61
+FROM ghcr.io/nanobot-ai/nanobot:v0.0.66
 
 USER root
 

--- a/mcp-servers/Dockerfile.github
+++ b/mcp-servers/Dockerfile.github
@@ -1,6 +1,6 @@
 FROM ghcr.io/github/github-mcp-server AS binary
 
-FROM ghcr.io/nanobot-ai/nanobot:v0.0.61
+FROM ghcr.io/nanobot-ai/nanobot:v0.0.66
 
 COPY --from=binary /server/github-mcp-server .
 
@@ -25,6 +25,6 @@ RUN chown 1000 nanobot.yaml
 
 ENTRYPOINT ["nanobot"]
 
-CMD ["run", "--listen-address", ":8099", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-e", "GITHUB_TOOLSETS", "-e", "GITHUB_DYNAMIC_TOOLSETS", "-e", "GITHUB_HOST", "--config", "./nanobot.yaml"]
+CMD ["run", "--listen-address", ":8099", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-e", "GITHUB_TOOLSETS", "-e", "GITHUB_DYNAMIC_TOOLSETS", "-e", "GITHUB_HOST", "--config", "./nanobot.yaml", "--disable-ui", "--exclude-built-in-agents"]
 
 USER 1000

--- a/mcp-servers/Dockerfile.hubspot
+++ b/mcp-servers/Dockerfile.hubspot
@@ -30,10 +30,10 @@ EOF
 
 RUN chown 1000 /nanobot.yaml
 
-COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.61 /usr/local/bin/nanobot /usr/local/bin/
+COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.66 /usr/local/bin/nanobot /usr/local/bin/
 
 ENTRYPOINT ["nanobot"]
 
-CMD ["run", "--listen-address", ":8099", "-e", "PRIVATE_APP_ACCESS_TOKEN", "--config", "/nanobot.yaml"]
+CMD ["run", "--listen-address", ":8099", "-e", "PRIVATE_APP_ACCESS_TOKEN", "--config", "/nanobot.yaml", "--disable-ui", "--exclude-built-in-agents"]
 
 USER 1000

--- a/scripts/nanobot.sh
+++ b/scripts/nanobot.sh
@@ -46,4 +46,4 @@ fi
 # Write the YAML file
 echo "$yaml_content" > /home/user/nanobot.yaml
 
-nanobot run --listen-address :8099 ${nanobot_args} --config /home/user/nanobot.yaml
+nanobot run --listen-address :8099 ${nanobot_args} --config /home/user/nanobot.yaml --disable-ui --exclude-built-in-agents


### PR DESCRIPTION
These extra flags are to ensure that the nanobot is just a proxy MCP server.