### PR TITLE
chore: bump nanobot image

### DIFF
--- a/Dockerfile.nanobot
+++ b/Dockerfile.nanobot
@@ -3,7 +3,7 @@ FROM ${BASE_IMAGE}
 
 USER root
 
-COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.76 /usr/local/bin/nanobot /usr/local/bin/
+COPY --from=ghcr.io/obot-platform/nanobot:v0.0.80 /usr/local/bin/nanobot /usr/local/bin/
 
 COPY ./scripts/nanobot.sh /usr/local/bin/nanobot.sh
 

--- a/Dockerfile.stdio-wrapper
+++ b/Dockerfile.stdio-wrapper
@@ -1,4 +1,4 @@
-FROM ghcr.io/nanobot-ai/nanobot:v0.0.76
+FROM ghcr.io/obot-platform/nanobot:v0.0.80
 
 USER root
 

--- a/mcp-servers/Dockerfile.github
+++ b/mcp-servers/Dockerfile.github
@@ -1,6 +1,6 @@
 FROM ghcr.io/github/github-mcp-server AS binary
 
-FROM ghcr.io/nanobot-ai/nanobot:v0.0.76
+FROM ghcr.io/obot-platform/nanobot:v0.0.80
 
 COPY --from=binary /server/github-mcp-server .
 

--- a/mcp-servers/Dockerfile.hubspot
+++ b/mcp-servers/Dockerfile.hubspot
@@ -30,7 +30,7 @@ EOF
 
 RUN chown 1000 /nanobot.yaml
 
-COPY --from=ghcr.io/nanobot-ai/nanobot:v0.0.76 /usr/local/bin/nanobot /usr/local/bin/
+COPY --from=ghcr.io/obot-platform/nanobot:v0.0.80 /usr/local/bin/nanobot /usr/local/bin/
 
 ENTRYPOINT ["nanobot"]
 


### PR DESCRIPTION
This updates the nanobot image to the latest and the new repo.