### PR TITLE
chore: remove obsolete Nanobot UI flags

### DIFF
--- a/mcp-servers/Dockerfile.github
+++ b/mcp-servers/Dockerfile.github
@@ -25,6 +25,6 @@ RUN chown 1000 nanobot.yaml
 
 ENTRYPOINT ["nanobot"]
 
-CMD ["run", "--listen-address", ":8099", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-e", "GITHUB_TOOLSETS", "-e", "GITHUB_DYNAMIC_TOOLSETS", "-e", "GITHUB_HOST", "--config", "./nanobot.yaml", "--disable-ui", "--exclude-built-in-agents"]
+CMD ["run", "--listen-address", ":8099", "-e", "GITHUB_PERSONAL_ACCESS_TOKEN", "-e", "GITHUB_TOOLSETS", "-e", "GITHUB_DYNAMIC_TOOLSETS", "-e", "GITHUB_HOST", "--config", "./nanobot.yaml", "--exclude-built-in-agents"]
 
 USER 1000

--- a/mcp-servers/Dockerfile.hubspot
+++ b/mcp-servers/Dockerfile.hubspot
@@ -34,6 +34,6 @@ COPY --from=ghcr.io/obot-platform/nanobot:v0.0.89 /usr/local/bin/nanobot /usr/lo
 
 ENTRYPOINT ["nanobot"]
 
-CMD ["run", "--listen-address", ":8099", "-e", "PRIVATE_APP_ACCESS_TOKEN", "--config", "/nanobot.yaml", "--disable-ui", "--exclude-built-in-agents"]
+CMD ["run", "--listen-address", ":8099", "-e", "PRIVATE_APP_ACCESS_TOKEN", "--config", "/nanobot.yaml", "--exclude-built-in-agents"]
 
 USER 1000

--- a/scripts/nanobot.sh
+++ b/scripts/nanobot.sh
@@ -46,4 +46,4 @@ fi
 # Write the YAML file
 echo "$yaml_content" > /home/user/nanobot.yaml
 
-nanobot run --listen-address :8099 ${nanobot_args} --config /home/user/nanobot.yaml --disable-ui --exclude-built-in-agents
+nanobot run --listen-address :8099 ${nanobot_args} --config /home/user/nanobot.yaml --exclude-built-in-agents


### PR DESCRIPTION
## Summary

- remove obsolete `--disable-ui` arguments from the Nanobot wrapper and MCP server images
- preserve all remaining Nanobot launch behavior

## Dependency

Depends on obot-platform/nanobot#353. Before this PR is ready to merge, update the Nanobot image version tags from `v0.0.89` to the release containing that change.

## Validation

- verified there are no remaining `--disable-ui` references
- validated `scripts/nanobot.sh` with `sh -n`
- built the Nanobot, GitHub, and HubSpot images locally
- inspected the packaged GitHub and HubSpot commands