### PR TITLE
fix: scan built images with Trivy

### DIFF
--- a/.github/workflows/base-images.yml
+++ b/.github/workflows/base-images.yml
@@ -11,6 +11,7 @@ on:
     paths:
       - Dockerfile.base-python
       - Dockerfile.base-node
+      - .github/workflows/base-images.yml
 jobs:
   docker-build:
     permissions:
@@ -18,6 +19,7 @@ jobs:
       packages: write
       actions: read
       id-token: write
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -66,35 +68,22 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}@${{ steps.build-and-push.outputs.digest }}
+          skip-dirs: "**/venv"
+          format: "sarif"
+          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
+          exit-code: "0"
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          category: trivy-${{ matrix.image-identifier }}
+          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif
       - name: Setup crane
         uses: imjasonh/setup-crane@v0.4
       - name: Copy image to latest tag
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }} latest
-
-  trivy-scan:
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    needs: docker-build
-    strategy:
-      fail-fast: false
-      matrix:
-        image-identifier:
-          - base-python
-          - base-node
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }}
-          skip-dirs: "**/venv"
-          format: "sarif"
-          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif

--- a/.github/workflows/mcp-servers.yml
+++ b/.github/workflows/mcp-servers.yml
@@ -12,6 +12,7 @@ on:
       - mcp-servers/**
       - http-webhook-mcp-converter/**
       - hubspot/**
+      - .github/workflows/mcp-servers.yml
 jobs:
   docker-build:
     permissions:
@@ -19,6 +20,7 @@ jobs:
       packages: write
       actions: read
       id-token: write
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -72,35 +74,22 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}@${{ steps.build-and-push.outputs.digest }}
+          skip-dirs: "**/venv"
+          format: "sarif"
+          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
+          exit-code: "0"
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          category: trivy-${{ matrix.image-identifier }}
+          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif
       - name: Setup crane
         uses: imjasonh/setup-crane@v0.4
       - name: Copy image to latest tag
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }} latest
-
-  trivy-scan:
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    needs: docker-build
-    strategy:
-      fail-fast: false
-      matrix:
-        image-identifier:
-          - base-python
-          - base-node
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }}
-          skip-dirs: "**/venv"
-          format: "sarif"
-          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif

--- a/.github/workflows/repackage.yml
+++ b/.github/workflows/repackage.yml
@@ -10,6 +10,8 @@ on:
       - "v*"
     paths:
       - repackaging/**
+      - Dockerfile.nanobot
+      - .github/workflows/repackage.yml
 
 jobs:
   generate-matrix:
@@ -31,6 +33,7 @@ jobs:
       packages: write
       actions: read
       id-token: write
+      security-events: write
     needs: generate-matrix
     strategy:
       fail-fast: false
@@ -122,13 +125,24 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.version }}
 
       - name: Setup crane
-        if: ${{ matrix.type == 'docker' }}
         uses: imjasonh/setup-crane@v0.4
 
       - name: Retag existing docker image
         if: ${{ matrix.type == 'docker' && steps.check-image.outputs.exists == 'false' }}
         run: |
           crane copy ${{ matrix.package }}:${{ matrix.version }} ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.version }}
+
+      - name: Resolve image digest
+        id: image
+        env:
+          IMAGE: ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.version }}
+          BUILD_DIGEST: ${{ steps.build-final.outputs.digest }}
+        run: |
+          digest="$BUILD_DIGEST"
+          if [ -z "$digest" ]; then
+            digest=$(crane digest "$IMAGE")
+          fi
+          echo "ref=${IMAGE%:*}@${digest}" >> "$GITHUB_OUTPUT"
 
       - name: Install Cosign
         uses: sigstore/cosign-installer@v4.1.1
@@ -151,13 +165,27 @@ jobs:
           cosign sign --yes ${images}
 
       - name: Generate SBOM
-        if: steps.check-image.outputs.exists == 'true'
         uses: anchore/sbom-action@v0.24.0
         with:
-          image: ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.version }}
+          image: ${{ steps.image.outputs.ref }}
           artifact-name: sbom-${{ matrix.name }}-${{ matrix.version }}.spdx.json
           dependency-snapshot: false
           upload-artifact-retention: 30
+
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ${{ steps.image.outputs.ref }}
+          skip-dirs: "**/venv"
+          format: "sarif"
+          output: "trivy-results-${{ matrix.name }}.sarif"
+          exit-code: "0"
+
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          category: trivy-${{ matrix.name }}
+          sarif_file: trivy-results-${{ matrix.name }}.sarif
 
       - name: trigger catalog update
         if: steps.check-image.outputs.exists == 'false'
@@ -174,31 +202,3 @@ jobs:
               "package": "${{ matrix.package }}",
               "type": "${{ matrix.type }}"
             }
-
-  trivy-scan:
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    needs: [generate-matrix, repackage]
-    strategy:
-      fail-fast: false
-      matrix:
-        include: ${{ fromJson(needs.generate-matrix.outputs.matrix) }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy
-        if: steps.check-image.outputs.exists == 'true' || steps.build-final.outputs.digest != ''
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.name }}:${{ matrix.version }}
-          skip-dirs: "**/venv,**/.local/share/uv/tools"
-          format: "sarif"
-          output: "trivy-results-${{ matrix.name }}-${{ matrix.version }}.sarif"
-
-      - name: Upload SARIF file
-        if: steps.check-image.outputs.exists == 'true' || steps.build-final.outputs.digest != ''
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          category: trivy-${{ matrix.name }}-${{ matrix.version }}
-          sarif_file: trivy-results-${{ matrix.name }}-${{ matrix.version }}.sarif

--- a/.github/workflows/stdio-wrapper-image.yml
+++ b/.github/workflows/stdio-wrapper-image.yml
@@ -10,6 +10,7 @@ on:
       - "v*"
     paths:
       - Dockerfile.stdio-wrapper
+      - .github/workflows/stdio-wrapper-image.yml
 jobs:
   docker-build:
     permissions:
@@ -17,6 +18,7 @@ jobs:
       packages: write
       actions: read
       id-token: write
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -64,35 +66,22 @@ jobs:
             images+="${tag}@${DIGEST} "
           done
           cosign sign --yes ${images}
+      - name: Run Trivy
+        uses: aquasecurity/trivy-action@v0.36.0
+        with:
+          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}@${{ steps.build-and-push.outputs.digest }}
+          skip-dirs: "**/venv"
+          format: "sarif"
+          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
+          exit-code: "0"
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          category: trivy-${{ matrix.image-identifier }}
+          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif
       - name: Setup crane
         uses: imjasonh/setup-crane@v0.4
       - name: Copy image to latest tag
         if: ${{ github.ref_type == 'tag' && !contains(github.ref_name, '-rc') }}
         run: |
           crane tag ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }} latest
-
-  trivy-scan:
-    permissions:
-      contents: read
-      packages: read
-      security-events: write
-    needs: docker-build
-    strategy:
-      fail-fast: false
-      matrix:
-        image-identifier:
-          - base-python
-          - base-node
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run Trivy
-        uses: aquasecurity/trivy-action@0.35.0
-        with:
-          image-ref: ghcr.io/${{ github.repository }}/${{ matrix.image-identifier }}:${{ github.ref_name }}
-          skip-dirs: "**/venv"
-          format: "sarif"
-          output: "trivy-results-${{ matrix.image-identifier }}.sarif"
-      - name: Upload SARIF file
-        uses: github/codeql-action/upload-sarif@v3
-        with:
-          sarif_file: trivy-results-${{ matrix.image-identifier }}.sarif


### PR DESCRIPTION
## Summary
- scan each image inside its build matrix job using the exact pushed image digest
- fix the MCP server and stdio wrapper workflows so they scan the images they actually build
- upload non-blocking Trivy SARIF results under stable per-image categories
- generate repackaged-image SBOMs from immutable digest references and trigger workflows when their definitions change

## Validation
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/repackage.yml .github/workflows/base-images.yml .github/workflows/mcp-servers.yml .github/workflows/stdio-wrapper-image.yml`
- parsed all changed workflows as YAML
- `git diff --check`

## Notes
Trivy remains reporting-only with `exit-code: "0"`; this does not add a high/critical vulnerability gate.