### PR TITLE
fix: pin Tableau MCP version

### DIFF
--- a/mcp-servers/Dockerfile.tableau
+++ b/mcp-servers/Dockerfile.tableau
@@ -4,9 +4,9 @@ WORKDIR /app
 # Install git for cloning
 RUN apk add --no-cache git
 
-# Clone tableau-mcp repository at a specific commit for reproducibility
+# Clone Tableau MCP v4.0.5 at a specific commit for reproducibility
 ARG TABLEAU_MCP_REPO=https://github.com/tableau/tableau-mcp.git
-ARG TABLEAU_MCP_COMMIT=main
+ARG TABLEAU_MCP_COMMIT=3561048f52983e6e81f457b705299779109040d1
 RUN git clone ${TABLEAU_MCP_REPO} . && \
     git checkout ${TABLEAU_MCP_COMMIT}
 


### PR DESCRIPTION
## Summary
- pin Tableau MCP to the v4.0.5 commit instead of tracking `main`
- make Tableau image builds reproducible and prevent unreviewed upstream changes from breaking startup

## Testing
- built the Tableau Docker image successfully
- verified the packaged version is 4.0.5
- reproduced the OAuth startup error without the catalog override
- verified `DANGEROUSLY_DISABLE_OAUTH=true` advances startup through PAT configuration to Tableau server discovery

Addresses https://github.com/obot-platform/obot/issues/7367