### PR TITLE
chore: remove obsolete Context7 image

### DIFF
--- a/repackaging/images.yaml
+++ b/repackaging/images.yaml
@@ -35,10 +35,6 @@ images:
     type: python
     package: chroma-mcp
     version: 0.2.6
-  - name: context7
-    type: node
-    package: "@upstash/context7-mcp"
-    version: 2.1.7
   - name: datadog
     type: node
     package: "@winor30/mcp-server-datadog"


### PR DESCRIPTION
## Summary

- remove the obsolete Context7 repackaging definition
- rely on Context7's official hosted remote MCP through mcp-catalog
- preserve shared build infrastructure and all unrelated images

## Validation

- parsed all 6 repository YAML files
- generated and validated the 29-entry repackaging matrix
- ran `docker buildx build --check` for all 13 Dockerfiles
- ran `git diff --check`
- confirmed no tracked Context7 image references remain

Related https://github.com/obot-platform/obot/issues/7377